### PR TITLE
Update now base type to use long

### DIFF
--- a/src/main/java/net/acesinc/data/json/generator/types/NowBaseType.java
+++ b/src/main/java/net/acesinc/data/json/generator/types/NowBaseType.java
@@ -47,19 +47,19 @@ public abstract class NowBaseType extends TypeHandler {
         long multiplier = 1;
         switch (unit) {
             case "y": {
-                multiplier = 1000 * 60 * 60 * 24 * 365;
+                multiplier = 1000 * 60 * 60 * 24 * 365L;
                 break;
             }
             case "d": {
-                multiplier = 1000 * 60 * 60 * 24;
+                multiplier = 1000 * 60 * 60 * 24L;
                 break;
             }
             case "h": {
-                multiplier = 1000 * 60 * 60;
+                multiplier = 1000 * 60 * 60L;
                 break;
             }
             case "m": {
-                multiplier = 1000 * 60;
+                multiplier = 1000 * 60L;
                 break;
             }
         }

--- a/src/test/java/net/acesinc/data/json/generator/types/NowBaseTypeTest.java
+++ b/src/test/java/net/acesinc/data/json/generator/types/NowBaseTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.acesinc.data.json.generator.types;
+
+import org.junit.*;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author denisgillespie
+ */
+public class NowBaseTypeTest {
+
+    public NowBaseTypeTest() {
+    }
+
+    @Before
+    public void setUp() {
+
+    }
+
+    /**
+     * Test of getTimeOffset method, of class NowBaseType.
+     */
+    @Test
+    public void testTimeOffsetReturnsCorrectTimeOffsetIfLargeNumber() {
+        assertTrue(NowBaseType.getTimeOffset("4_y") == 126144000000L && NowBaseType.getTimeOffset("4_y") > Integer.MAX_VALUE);
+        assertTrue(NowBaseType.getTimeOffset("-4_y") == -126144000000L && NowBaseType.getTimeOffset("-4_y") < Integer.MIN_VALUE);
+
+        assertTrue(NowBaseType.getTimeOffset("600_d") == 51840000000L && NowBaseType.getTimeOffset("600_y") > Integer.MAX_VALUE);
+        assertTrue(NowBaseType.getTimeOffset("-600_d") == -51840000000L && NowBaseType.getTimeOffset("-600_y") < Integer.MIN_VALUE);
+
+        assertTrue(NowBaseType.getTimeOffset("40000_h") == 144000000000L && NowBaseType.getTimeOffset("40000_d") > Integer.MAX_VALUE);
+        assertTrue(NowBaseType.getTimeOffset("-40000_h") == -144000000000L && NowBaseType.getTimeOffset("-40000_d") < Integer.MIN_VALUE);
+
+        assertTrue(NowBaseType.getTimeOffset(Integer.MAX_VALUE + "_m") == 128849018820000L && NowBaseType.getTimeOffset(Integer.MAX_VALUE + "_m")  > Integer.MAX_VALUE);
+        assertTrue(NowBaseType.getTimeOffset("-" + Integer.MAX_VALUE + "_m") == -128849018820000L && NowBaseType.getTimeOffset("-" + Integer.MAX_VALUE + "_m") < Integer.MIN_VALUE);
+    }
+
+}

--- a/src/test/java/net/acesinc/data/json/generator/types/NowBaseTypeTest.java
+++ b/src/test/java/net/acesinc/data/json/generator/types/NowBaseTypeTest.java
@@ -7,11 +7,6 @@ package net.acesinc.data.json.generator.types;
 
 import org.junit.*;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.GregorianCalendar;
-
 import static org.junit.Assert.*;
 
 /**


### PR DESCRIPTION
Hi @andrewserff ,
I noticed that the time offset returned from the NowBaseType (when you pass an argument to the now() function) was an integer. So if you used "now(4_y)" for example it sets the value to the max integer value and doesn't give the correct date.
