### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM maven:3.6.3-jdk-11
+
+# Install any missing dependencies for your environment here
+
+# For example:
+# RUN apt-get update && apt-get install -y maven

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "Java Project",
+  "dockerFile": "Dockerfile",
+  "settings": { 
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": [
+    "vscjava.vscode-java-pack"
+  ],
+  "forwardPorts": [],
+  "postCreateCommand": "mvn clean package"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,50 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Current File",
+            "request": "launch",
+            "mainClass": "${file}"
+        },
+        {
+            "type": "java",
+            "name": "JsonDataGenerator",
+            "request": "launch",
+            "mainClass": "net.acesinc.data.json.generator.JsonDataGenerator",
+            "projectName": "json-data-generator"
+        },
+        {
+            "type": "java",
+            "name": "JsonGenerator",
+            "request": "launch",
+            "mainClass": "net.acesinc.data.json.generator.JsonGenerator",
+            "projectName": "json-data-generator"
+        },
+        {
+            "type": "java",
+            "name": "TypeHandlerFactory",
+            "request": "launch",
+            "mainClass": "net.acesinc.data.json.generator.types.TypeHandlerFactory",
+            "projectName": "json-data-generator"
+        },
+        {
+            "type": "java",
+            "name": "Debug (Launch) - Main",
+            "request": "launch",
+            "mainClass": "net.acesinc.data.json.generator.JsonDataGenerator",
+            "projectName": "json-data-generator",
+            "args": ["exampleSimConfig.json"],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "externalTerminalOptions": {
+                "cwd": "${workspaceFolder}"
+            },
+            "vmArgs": "-Dfile.encoding=UTF-8"
+        }
+ 
+    ]
+}


### PR DESCRIPTION
This pull request introduces changes to support a development environment for a Java project using Docker and Visual Studio Code. The most important changes include the addition of a `Dockerfile` to define the Docker environment, a `devcontainer.json` file to configure the Visual Studio Code development container, and a `launch.json` file to set up debugging configurations for the Java project.

Docker environment setup:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R1-R6): A Dockerfile was added that uses the `maven:3.6.3-jdk-11` image as a base. This means the development environment will have Maven and JDK 11 pre-installed.

Visual Studio Code development container configuration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R12): A `devcontainer.json` file was added to configure the Visual Studio Code development container. This file specifies the Dockerfile to use for the container, sets the terminal shell to bash, includes the Java extension pack for Visual Studio Code, and defines a post creation command to clean and package the Maven project.

Java project debugging setup:

* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R1-R50): A `launch.json` file was added to set up different debugging configurations for the Java project. This file includes configurations for running and debugging different main classes in the project.